### PR TITLE
added isRegEmpty for loss variable problem hotfix

### DIFF
--- a/Compiler/src/CompilerCode/RegStack.java
+++ b/Compiler/src/CompilerCode/RegStack.java
@@ -101,6 +101,30 @@ public class RegStack {
 		return setReg(findLRUReg(), value);
 	}
 
+	/**
+	 * hotfix to the "loss of a variable if pushed to the stack while trying to push to reg" problem (can't return 2 ints)
+	 * @return true if the LRU reg is empty (0)
+	 */
+	public boolean isRegEmpty(){
+		int tmp = stack.get(this.findLRUReg());
+		if(tmp == 0){
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * hotfix to the "loss of a variable if pushed to the stack while trying to push to reg" problem (can't return 2 ints)
+	 * @param reg the reg num in question if it's empty or not
+	 * @return true if the given reg number is empty (0)
+	 */
+	public boolean isRegEmpty(int reg){
+		int tmp = stack.get(reg);
+		if(tmp == 0){
+			return true;
+		}
+		return false;
+	}
 	
 	public int getReg(int reg){
 		incrementLRU();


### PR DESCRIPTION
added isRegEmpty for "loss of a variable if pushed to the stack while trying to push to reg" problem hotfix as it's unclean and inconsistent to try to return an int array. Just check if the reg you're trying to use is empty, if not push the reg to stack (giving you the reg value's location on the stack) before moving the var you want to the register in question. defaults to the LRU reg if no argument given.